### PR TITLE
Update cmake_minimum_required to silence warning from CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(nofmt-join)
 
 set(CMAKE_CXX_STANDARD 20)


### PR DESCRIPTION
The build doesn't actually change as far as I can tell.